### PR TITLE
use OS::Nova::Server resource

### DIFF
--- a/django-single.yaml
+++ b/django-single.yaml
@@ -172,7 +172,7 @@ parameters:
 
 resources:
   django_server:
-    type: "Rackspace::Cloud::Server"
+    type: "OS::Nova::Server"
     properties:
       name: { get_param: server_hostname }
       flavor: { get_param: flavor }
@@ -214,7 +214,7 @@ resources:
 outputs:
 
   privateIPv4:
-    value: { get_attr: [django_server, privateIPv4] }
+    value: { get_attr: [django_server, networks, private, 0] }
 
   accessIPv4:
     value: { get_attr: [django_server, accessIPv4] }


### PR DESCRIPTION
Rackspace::Cloud::Server is now deprecated. R::C::S has somewhat
different attributes for the server IP addresses, so instead of
{ get_attr: [django_server, privateIPv4] } we must now use
{ get_attr: [django_server, networks, private, 0] }